### PR TITLE
Export toMatchSpecificSnapshot to make it extensible

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,16 @@
-# Jest Specific Snapshot #
+# Jest Specific Snapshot
 
 Jest matcher for multiple snapshot files per test
 
 <b>You can read about the implementation [here](https://medium.com/@davydkin.igor/adding-multi-snapshot-testing-to-jest-b61f23cf17ca)</b>
 
-# Installation #
+# Installation
 
 ```sh
-npm i -D jest-specific-snapshot 
+npm i -D jest-specific-snapshot
 ```
 
-# Example #
+# Example
 
 ```js
 const path = require('path');
@@ -30,7 +30,7 @@ test('test', () => {
 });
 ```
 
-## With Custom Serializer ##
+## With Custom Serializer
 
 ```js
 // extend jest to have 'toMatchSpecificSnapshot' matcher
@@ -39,13 +39,28 @@ const addSerializer = require('jest-specifics-snapshot').addSerializer;
 addSerializer(/* Add custom serializer here */);
 
 test('test', () => {
-  expect(/* thing that matches the custom serializer */)
-    .toMatchSpecificSnapshot('./specific/custom_serializer/test.shot');
+  expect(/* thing that matches the custom serializer */).toMatchSpecificSnapshot(
+    './specific/custom_serializer/test.shot'
+  );
 });
-``` 
+```
 
-# Limitations # 
+## Extend `toMatchSpecificSnapshot`
 
-1. Snapshot files should have an extension **other** than `.snap`, since it conflicts with jest.
-2. In order to handle the `--updateSnapshot` (`-u`) parameter provided from CLI, there is an abuse of the `SnapshotState._updateSnapshot` private field. TBD - try to use the `globalConfig` to get this state. 
-3. `.toMatchSpecificSnapshot` does ignore a custom serializers strategy. In order to support custom serializers, you should use the `addSerializer` method explicitly.
+```js
+const toMatchSpecificSnapshot = require('jest-specifics-snapshot').toMatchSpecificSnapshot;
+
+expect.extend({
+  toMatchDecoratedSpecificSnapshot(received, snapshotFile) {
+    // You can modify received data or create dynamic snapshot path
+    const data = doSomeThing(received);
+    return toMatchSpecificSnapshot.call(this, data, snapshotFile);
+  },
+});
+```
+
+# Limitations
+
+1.  Snapshot files should have an extension **other** than `.snap`, since it conflicts with jest.
+2.  In order to handle the `--updateSnapshot` (`-u`) parameter provided from CLI, there is an abuse of the `SnapshotState._updateSnapshot` private field. TBD - try to use the `globalConfig` to get this state.
+3.  `.toMatchSpecificSnapshot` does ignore a custom serializers strategy. In order to support custom serializers, you should use the `addSerializer` method explicitly.

--- a/example/specific.napshot.test.js
+++ b/example/specific.napshot.test.js
@@ -1,5 +1,11 @@
 import path from 'path';
-import { addSerializer } from '../src/index';
+import { addSerializer, toMatchSpecificSnapshot } from '../src/index';
+
+expect.extend({
+  toMatchExtendedSpecificSnapshot(received, snapshotFile) {
+    return toMatchSpecificSnapshot.call(this, received + 1, snapshotFile);
+  },
+});
 
 test('test that creates multiple snapshots', () => {
   const pathToSnap = path.resolve(process.cwd(), './example/specific/dir/my.shot');
@@ -24,4 +30,8 @@ test('with custom serializer', () => {
   expect('this value value will be serialized with the default serializer').toMatchSpecificSnapshot(
     './specific/custom_serializer/test3.shot'
   );
+});
+
+test('with extended matcher', () => {
+  expect(11).toMatchExtendedSpecificSnapshot('./specific/extended_matcher/test1.shot');
 });

--- a/example/specific/extended_matcher/test1.shot
+++ b/example/specific/extended_matcher/test1.shot
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`with extended matcher 1`] = `12`;

--- a/src/index.js
+++ b/src/index.js
@@ -22,26 +22,26 @@ afterAll(() => {
   });
 });
 
-expect.extend({
-  toMatchSpecificSnapshot(received, snapshotFile) {
-    const absoluteSnapshotFile = getAbsolutePathToSnapshot(this.testPath, snapshotFile);
+function toMatchSpecificSnapshot(received, snapshotFile) {
+  const absoluteSnapshotFile = getAbsolutePathToSnapshot(this.testPath, snapshotFile);
 
-    const commonSnapshotState = this.snapshotState;
-    let snapshotState = snapshotsStateMap.get(absoluteSnapshotFile);
+  const commonSnapshotState = this.snapshotState;
+  let snapshotState = snapshotsStateMap.get(absoluteSnapshotFile);
 
-    if (!snapshotState) {
-      snapshotState = new SnapshotState(absoluteSnapshotFile, {
-        updateSnapshot: commonSnapshotState._updateSnapshot,
-        snapshotPath: absoluteSnapshotFile,
-      });
-      snapshotsStateMap.set(absoluteSnapshotFile, snapshotState);
-    }
+  if (!snapshotState) {
+    snapshotState = new SnapshotState(absoluteSnapshotFile, {
+      updateSnapshot: commonSnapshotState._updateSnapshot,
+      snapshotPath: absoluteSnapshotFile,
+    });
+    snapshotsStateMap.set(absoluteSnapshotFile, snapshotState);
+  }
 
-    const newThis = Object.assign({}, this, { snapshotState });
-    const patchedToMatchSnapshot = toMatchSnapshot.bind(newThis);
+  const newThis = Object.assign({}, this, { snapshotState });
+  const patchedToMatchSnapshot = toMatchSnapshot.bind(newThis);
 
-    return patchedToMatchSnapshot(received);
-  },
-});
+  return patchedToMatchSnapshot(received);
+}
 
-export { addSerializer };
+expect.extend({ toMatchSpecificSnapshot });
+
+export { addSerializer, toMatchSpecificSnapshot };


### PR DESCRIPTION
I have moved `toMatchSpecificSnapshot` outside, made it a `function` and exported it. Now it's possible to extend it like `toMatchSnapshot`.