### PR TITLE
Fix different jest-snapshot in lockfiles

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "cacheDirectory": "./.jest/cache"
   },
   "dependencies": {
-    "jest-snapshot": ">=20.0.3"
+    "jest-snapshot": "^20.0.3"
   },
   "devDependencies": {
     "babel-cli": "^6.24.1",


### PR DESCRIPTION
**Yarn** thinks `jest-snapshot@>=20.0.3` and `jest-snapshot@^20.0.3` are two different thing. This change will allow Yarn to dedupe `jest-snapshot`. Otherwise, it produces unwanted result:

```
jest-snapshot@>=20.0.3:
  version "22.4.0"
  resolved "https://registry.yarnpkg.com/jest-snapshot/-/jest-snapshot-22.4.0.tgz#03d3ce63f8fa7352388afc6a3c8b5ccc3a180ed7"
  dependencies:
    chalk "^2.0.1"
    jest-diff "^22.4.0"
    jest-matcher-utils "^22.4.0"
    mkdirp "^0.5.1"
    natural-compare "^1.4.0"
    pretty-format "^22.4.0"

jest-snapshot@^20.0.3:
  version "20.0.3"
  resolved "https://registry.yarnpkg.com/jest-snapshot/-/jest-snapshot-20.0.3.tgz#5b847e1adb1a4d90852a7f9f125086e187c76566"
  dependencies:
    chalk "^1.1.3"
    jest-diff "^20.0.3"
    jest-matcher-utils "^20.0.3"
    jest-util "^20.0.3"
    natural-compare "^1.4.0"
    pretty-format "^20.0.3"
```