### PR TITLE
Changed jest-snapshot version to prevent breaking issues.

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "cacheDirectory": "./.jest/cache"
   },
   "dependencies": {
-    "jest-snapshot": ">=20.0.3"
+    "jest-snapshot": "^23.6.0"
   },
   "devDependencies": {
     "babel-cli": "^6.24.1",


### PR DESCRIPTION
The jest-snapshot 24.0.0 version has introduced a breaking change in the sub-dependency jest-resolve. A file has been renamed causing a breaking issue with my project. (storybook jest addon)

Considering that storybook is a widely used module, it seems prudent to fix this. It's also a good idea to lock the version to non-breaking changes to prevent stuff like this.