### PR TITLE
Added types to extend jest namespace

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "license": "MIT",
   "repository": "https://github.com/igor-dv/jest-specific-snapshot",
   "main": "dist/index.js",
+  "types": "types.d.ts",
   "scripts": {
     "test": "jest specific.snapshot.test",
     "babel": "babel src -d dist",

--- a/types.d.ts
+++ b/types.d.ts
@@ -1,0 +1,9 @@
+export {};
+
+declare global {
+  namespace jest {
+    interface Matchers<R> {
+      toMatchSpecificSnapshot(path: string, name?: string): R;
+    }
+  }
+}


### PR DESCRIPTION
Now if you write your tests in typescript you can simply import `jest-specific-snapshot` to have your jest `expect `type extended

```ts
import 'jest-specific-snapshot'

// type checks 🎉
expect('').toMatchSpecificSnapshot('file')
```